### PR TITLE
Fixed issue with CocoaLumberjack logger context

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Initialize the file-logger with the specified options. As soon as the returned p
 | `maximumFileSize` | A new log file is created when current log file exceeds the given size in bytes. `0` to disable | `1024 * 1024` (1MB) |
 | `maximumNumberOfFiles` | Maximum number of log files to keep. When a new log file is created, if the total number of files exceeds this limit, the oldest file is deleted. `0` to disable | `5` |
 | `logsDirectory` | Absolute path of directory where log files are stored. If not defined, log files are stored in the cache directory of the app | `undefined` |
+| `loggerContext` (iOS only) | You should change logger context if other CocoaLumberjack loggers are write to your log file. To prevent it change the context value to any integer number that differ from already taken contexts. CocoaLumberjack use `0` as default. | `0` |
 
 #### FileLogger.sendLogFilesByEmail(options?): Promise
 

--- a/ios/FileLogger.h
+++ b/ios/FileLogger.h
@@ -2,4 +2,6 @@
 
 @interface FileLogger : NSObject <RCTBridgeModule>
 
++ (int)loggerContext;
+
 @end

--- a/ios/FileLoggerFormatter.m
+++ b/ios/FileLoggerFormatter.m
@@ -1,9 +1,14 @@
 #import "FileLoggerFormatter.h"
+#import "FileLogger.h"
 
 @implementation FileLoggerFormatter
 
 - (NSString*)formatLogMessage:(DDLogMessage*)logMessage {
-    return logMessage.message;
+    if (logMessage->_context == FileLogger.loggerContext) {
+        return logMessage.message;
+    } else {
+        return nil;
+    }
 }
 
 @end

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export interface ConfigureOptions {
 	maximumFileSize?: number;
 	maximumNumberOfFiles?: number;
 	logsDirectory?: string;
+	loggerContext?: number;
 }
 
 export interface SendByEmailOptions {
@@ -42,6 +43,7 @@ class FileLoggerStatic {
 			maximumFileSize = 1024 * 1024,
 			maximumNumberOfFiles = 5,
 			logsDirectory,
+			loggerContext = 0
 		} = options;
 
 		await RNFileLogger.configure({
@@ -49,6 +51,7 @@ class FileLoggerStatic {
 			maximumFileSize,
 			maximumNumberOfFiles,
 			logsDirectory,
+			loggerContext,
 		});
 
 		this._logLevel = logLevel;


### PR DESCRIPTION
Added possibility to set CocoaLumberjack logger context to prevent situations when other CocoaLumberjack loggers with same context are writes to the same log file.