### PR TITLE
Java implementation for logFiles parameter in sendLogFilesByEmail method

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ Initialize the file-logger with the specified options. As soon as the returned p
 
 Send all log files by email. On iOS, it uses `MFMailComposeViewController` to ensure that the user won't leave the app when sending log files.
 
-| Option | Description |
-| --- | --- |
-| `to` | Email address of the recipient |
-| `subject` | Email subject |
-| `body` | Plain text body message of the email |
+| Option     | Description                                                                                                                                  |
+|------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `to`       | Email address of the recipient                                                                                                               |
+| `subject`  | Email subject                                                                                                                                |
+| `body`     | Plain text body message of the email                                                                                                         |
+| `logFiles` | Log file selector, supports `all`, `latest`, `none` and arbitrary other strings that are matched against the log filename as a regex pattern |
 
 #### FileLogger.enableConsoleCapture()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export interface SendByEmailOptions {
 	to?: string | string[];
 	subject?: string;
 	body?: string;
+	logFiles?: string;
 }
 
 class FileLoggerStatic {


### PR DESCRIPTION
Demonstration of https://github.com/BeTomorrow/react-native-file-logger/issues/47 implemented for Android only. I (fortunately) never had to use objective-C so I don't really know how to approach this on ios.

Other methods (such as delete....) could support the same argument to allow the deletion of a subset of logs files and more. Simple yet powerful feature.

This is **NOT** ready to be merged, it is more like proof-of-concept. 