### PR TITLE
Avoid typescript error TS7017 by explicitly casting global

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { NativeModules } from "react-native";
 import util from "util";
 import type RNFileLoggerType from "./NativeFileLogger";
 
-const isTurboModuleEnabled = global.__turboModuleProxy != null;
+const isTurboModuleEnabled = (global as any).__turboModuleProxy != null;
 const RNFileLogger: typeof RNFileLoggerType = isTurboModuleEnabled
 	? require("./NativeFileLogger").default
 	: NativeModules.FileLogger;


### PR DESCRIPTION
First, thanks for that useful module.

We found-out when upgrading to version 6.0 that running `tsc -noEmit` on a project using that module would trigger the following error:

```
error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
```

This pull-request addresses this by explicitly casting `global` to any before using it.

