### PR TITLE
Fix: Prevent Console Re-Patching and Handle Disabling on Configure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,10 +70,16 @@ class FileLoggerStatic {
 
 		if (captureConsole) {
 			this.enableConsoleCapture();
+		} else {
+			this.disableConsoleCapture();
 		}
 	}
 
 	enableConsoleCapture() {
+		if (this._originalConsole) {
+			return;
+		}
+
 		// Store original console methods
 		this._originalConsole = {
 			debug: console.debug,


### PR DESCRIPTION
Closes #82

Without this, everytime `configure` is called due to hot reload, console.log will have 1 extra stack, and with enough hot reloads, it will stackoverflow, but will be triggered by until.inspect, which internally uses str.replace and throw "Maximum regex stack depth reached" error

**Summary of Changes**:
- This change prevents the `console` object from being patched multiple times by adding a guard in the `enableConsoleCapture` method.
- The `configure` method has been updated to correctly disable console capturing when the `captureConsole` option is set to `false`.
